### PR TITLE
[HOPSWORKS-1643] Fix multiline support for kagent

### DIFF
--- a/recipes/_filebeat-kagent.rb
+++ b/recipes/_filebeat-kagent.rb
@@ -20,6 +20,7 @@ template "#{node['filebeat']['base_dir']}/filebeat-kagent.yml" do
   variables({
               :paths => commands_log,
               :multiline => true,
+              :multiline_pattern => '\'[0-9]{4}-[0-9]{2}-[0-9]{2}\'',
               :logstash_endpoint => logstash_endpoint,
               :log_name => "kagent"
   })


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1643

The log file that filebeat tails look like:
```
2020-03-18 12:25:42,212 INFO project_c45eda6f358c0ba0 CREATE ProJect_c45eda6f358c0ba0 3.6 -1 WORKING
2020-03-18 12:26:06,920 INFO project_c45eda6f358c0ba0 CREATE ProJect_c45eda6f358c0ba0 3.6 0 SUCCESS
2020-03-18 12:26:06,922 INFO project_c45eda6f358c0ba0 INSTALL paramiko 2.4.2 -1 WORKING
2020-03-18 12:26:17,748 INFO project_c45eda6f358c0ba0 INSTALL paramiko 2.4.2 0 SUCCESS
2020-03-18 12:28:25,878 INFO project_9a0db0d4f8c240ed CREATE ProJect_9a0db0d4f8c240ed 3.6 -1 WORKING
2020-03-18 12:28:51,159 INFO project_9a0db0d4f8c240ed CREATE ProJect_9a0db0d4f8c240ed 3.6 0 SUCCESS
2020-03-18 12:28:51,160 INFO project_9a0db0d4f8c240ed INSTALL imageio 2.2.0 -1 WORKING
2020-03-18 12:29:00,846 INFO project_9a0db0d4f8c240ed INSTALL imageio 2.2.0 0 SUCCESS
2020-03-18 12:29:00,847 INFO project_9a0db0d4f8c240ed INSTALL dropbox 9.0.0 -1 WORKING
2020-03-18 12:29:09,428 INFO project_9a0db0d4f8c240ed INSTALL dropbox 9.0.0 0 SUCCESS
```