### PR TITLE
[HWORKS-310] Disable TLS1.1 for Opensearch dashboard

### DIFF
--- a/templates/default/opensearch_dashboards.yml.erb
+++ b/templates/default/opensearch_dashboards.yml.erb
@@ -76,6 +76,7 @@ opensearch.password: "<%= node['elastic']['opensearch_security']['kibana']['pass
 server.ssl.enabled: <%= node['kibana']['opensearch_security']['https']['enabled'] %>
 server.ssl.certificate: <%= @certificate %>
 server.ssl.key: <%= @private_key %>
+server.ssl.supportedProtocols: ['TLSv1.2']
 
 
 # Optional settings that provide the paths to the PEM-format SSL certificate and key files.
@@ -157,6 +158,7 @@ opensearch_security.jwt.url_param: <%= node['elastic']['opensearch_security']['j
 
 #cookies
 opensearch_security.cookie.ttl: <%=node['kibana']['opensearch_security']['cookie']['ttl']%>
+opensearch_security.cookie.secure: <%=node['kibana']['opensearch_security']['https']['enabled'] %>
 opensearch_security.session.ttl: <%=node['kibana']['opensearch_security']['session']['ttl']%>
 opensearch_security.session.keepalive: <%=node['kibana']['opensearch_security']['session']['keepalive'].casecmp?("true")%>
 


### PR DESCRIPTION
Jira: https://hopsworks.atlassian.net/browse/HWORKS-310

- Disable TLS version 1.1
- Set secure cookie if HTTPS is enabled